### PR TITLE
[BUGFIX] Fix scope of refresh button to refresh correct widget

### DIFF
--- a/Resources/Public/JavaScript/Backend/DashboardManager/ViewModel.js
+++ b/Resources/Public/JavaScript/Backend/DashboardManager/ViewModel.js
@@ -334,7 +334,6 @@ define(['require',
                 var $currentWidget = $(this);
                 $currentWidget.find(reloadButtonSelector).on('click', function(e) {
                     e.preventDefault();
-                    console.log($currentWidget);
                     updateWidgetContent($currentWidget.find(contentSelector));
                 });
             });

--- a/Resources/Public/JavaScript/Backend/DashboardManager/ViewModel.js
+++ b/Resources/Public/JavaScript/Backend/DashboardManager/ViewModel.js
@@ -330,9 +330,13 @@ define(['require',
                 reloadButtonSelector = getDomElementIdentifier('refreshWidgetTrigger'),
                 $widgetElement = $('.js-widget');
 
-            $widgetElement.find(reloadButtonSelector).on('click', function(e) {
-                e.preventDefault();
-                updateWidgetContent($widgetElement.find(contentSelector));
+            $widgetElement.each(function() {
+                var $currentWidget = $(this);
+                $currentWidget.find(reloadButtonSelector).on('click', function(e) {
+                    e.preventDefault();
+                    console.log($currentWidget);
+                    updateWidgetContent($currentWidget.find(contentSelector));
+                });
             });
         }
 


### PR DESCRIPTION
If there are more than one widget on a dashboard, the refresh button will be triggered for all widgets and refresh just one endpoint, thus the all widgets show the same content.

With this fix the refresh button will keep the scope of the widget.